### PR TITLE
feature/EXT-1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,5 @@ target/
 .idea
 /manage.py
 example
+
+venv/

--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ INSTALLED_APPS = (
 )
 ```
 
+If request.user is not represented by AUTH_USER_MODEL in your application then you can set up a custom Users model:
+
+```python
+LOGGING_USER_MODEL = 'yourapp.Users'
+# By default, LOGGING_USER_MODEL = AUTH_USER_MODEL
+```
+
+
+
 2. make migrations
 3. add the models you want to log in settings.py, format:
 ```python

--- a/models_logging/migrations/0001_initial.py
+++ b/models_logging/migrations/0001_initial.py
@@ -13,7 +13,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('contenttypes', '0002_remove_content_type_name'),
-        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        migrations.swappable_dependency(settings.LOGGING_USER_MODEL),
     ]
 
     operations = [
@@ -57,6 +57,13 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='changes',
             name='user',
-            field=models.ForeignKey(blank=True, help_text='The user who created this changes.', null=True, on_delete=django.db.models.deletion.SET_NULL, to=settings.AUTH_USER_MODEL, verbose_name='User'),
+            field=models.ForeignKey(
+                blank=True,
+                help_text='A user who performed a change',
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                to=settings.LOGGING_USER_MODEL,
+                verbose_name='User'
+            )
         ),
     ]

--- a/models_logging/models.py
+++ b/models_logging/models.py
@@ -50,7 +50,7 @@ class Change(models.Model):
 
     date_created = models.DateTimeField(_("Date created"), db_index=True, auto_now_add=True,
                                         help_text=_("The date and time this changes was."))
-    user = models.ForeignKey(settings.AUTH_USER_MODEL, blank=True, null=True, on_delete=models.SET_NULL,
+    user = models.ForeignKey(settings.LOGGING_USER_MODEL, blank=True, null=True, on_delete=models.SET_NULL,
                              verbose_name=_("User"), help_text=_("The user who created this changes."))
     object_id = models.IntegerField(help_text=_("Primary key of the model under version control."))
     content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE,

--- a/models_logging/settings.py
+++ b/models_logging/settings.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 
+LOGGING_USER_MODEL = getattr(settings, 'LOGGING_USER_MODEL', None) or getattr(settings, 'AUTH_USER_MODEL', None)
 
 MODELS_FOR_LOGGING = getattr(settings, 'LOGGING_MODELS', None)
 MODELS_FOR_EXCLUDE = getattr(settings, 'LOGGING_EXCLUDE', [])


### PR DESCRIPTION
**What:**
- Allow setting a User model which differs from the common AUTH_USER_MODEL using LOGGING_USER_MODEL.
- If LOGGING_USER_MODEL is not set then use AUTH_USER_MODEL (in order not to spoil previous functionality)


**Why:**
- Currently `_local.user = request.user`.
In rare occasions, request.user does not stand for django_users. This case might be represented as a result of merging 2 or more enormously large projects. Or gradual move from one type of DB to another. Or the interaction of multiple systems which use their own `users` but still it represents the same instance. 
As a result, there'd be multiple `users` tables in different DBs which are impossible to be merged into a single `django_users` at the moment. 

To conclude, Django can work with multiple DBs then request.user can be represented not by AUTH_USER_MODEL but by something else.