### PR TITLE
Feature/ext 7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,5 @@ target/
 .idea
 /manage.py
 example
+
+venv/

--- a/README.md
+++ b/README.md
@@ -98,6 +98,21 @@ class YourAdminModel(HistoryAdmin):
 
 ```
 
+If you want to exclude some actions from being logged in order to save storage or for some other reasons then you can attach a meta-class Logging and set an attribute ignore_on_create:
+
+```python
+from django.db import models
+
+class YourModel(models.Model):
+    name = models.CharField(max_length=1000)
+    
+    class Logging:
+        ignore_on_create = True # False by default
+```
+It will skip attempts to create any logs that an instance of this model has been created. 
+Please note, setting up *ignore_on_...* as True will cause impossibility of reverting your data.
+
+
 
 Version > 1.0 is incompatible with old versions (requires django >= 2.0)
 for django <= 2.0 use 0.9.7 version

--- a/README.md
+++ b/README.md
@@ -133,6 +133,21 @@ class YourModel(models.Model):
 Even if `name` was not changed it will always be in a log.
 
 
+You can also track specific fields ignoring others using `trackable_fields`:
+```python
+from django.db import models
+
+class YourModel(models.Model):
+    name = models.CharField(max_length=1000)
+    description = models.CharField(max_length=1000)
+        
+    class Logging:
+        trackable_fields = (
+            'name',
+        )
+```
+Change of `description` will be ignored. No log will be created.
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ INSTALLED_APPS = (
 )
 ```
 
+If request.user is not represented by AUTH_USER_MODEL in your application then you can set up a custom Users model:
+
+```python
+LOGGING_USER_MODEL = 'yourapp.Users'
+# By default, LOGGING_USER_MODEL = AUTH_USER_MODEL
+```
+
+
+
 2. make migrations
 3. add the models you want to log in settings.py, format:
 ```python

--- a/README.md
+++ b/README.md
@@ -117,6 +117,25 @@ class YourModel(models.Model):
 Please note, setting up *ignore_on_...* as True will cause impossibility of reverting your data.
 
 
+If you want some fields to be logged always then you can use the `always_show` field:
+```python
+from django.db import models
+
+class YourModel(models.Model):
+    name = models.CharField(max_length=1000)
+    description = models.CharField(max_length=1000)
+        
+    class Logging:
+        always_show = (
+            'name',
+        )
+```
+Even if `name` was not changed it will always be in a log.
+
+
+
+
+
 
 Version > 1.0 is incompatible with old versions (requires django >= 2.0)
 for django <= 2.0 use 0.9.7 version

--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ class YourAdminModel(HistoryAdmin):
 
 ```
 
-If you want to exclude some actions from being logged in order to save storage or for some other reasons then you can attach a meta-class Logging and set an attribute ignore_on_create:
+If you want to exclude some actions from being logged in order to save storage or for some other reasons then you can attach a meta-class Logging and set the following attributes: 
+- ignore_on_create (False by default. Skips logging of `create` actions)
+- ignore_on_update (False by default. Skips logging of `update` actions)
 
 ```python
 from django.db import models
@@ -107,9 +109,9 @@ class YourModel(models.Model):
     name = models.CharField(max_length=1000)
     
     class Logging:
-        ignore_on_create = True # False by default
+        ignore_on_create = True
+        ignore_on_update = True
 ```
-It will skip attempts to create any logs that an instance of this model has been created. 
 Please note, setting up *ignore_on_...* as True will cause impossibility of reverting your data.
 
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ class YourAdminModel(HistoryAdmin):
 If you want to exclude some actions from being logged in order to save storage or for some other reasons then you can attach a meta-class Logging and set the following attributes: 
 - ignore_on_create (False by default. Skips logging of `create` actions)
 - ignore_on_update (False by default. Skips logging of `update` actions)
+- ignore_on_delete (False by default. Skips logging of `delete` actions)
 
 ```python
 from django.db import models
@@ -111,6 +112,7 @@ class YourModel(models.Model):
     class Logging:
         ignore_on_create = True
         ignore_on_update = True
+        ignore_on_delete = True
 ```
 Please note, setting up *ignore_on_...* as True will cause impossibility of reverting your data.
 

--- a/models_logging/migrations/0001_initial.py
+++ b/models_logging/migrations/0001_initial.py
@@ -13,7 +13,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('contenttypes', '0002_remove_content_type_name'),
-        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        migrations.swappable_dependency(settings.LOGGING_USER_MODEL),
     ]
 
     operations = [
@@ -57,6 +57,13 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='changes',
             name='user',
-            field=models.ForeignKey(blank=True, help_text='The user who created this changes.', null=True, on_delete=django.db.models.deletion.SET_NULL, to=settings.AUTH_USER_MODEL, verbose_name='User'),
+            field=models.ForeignKey(
+                blank=True,
+                help_text='A user who performed a change',
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                to=settings.LOGGING_USER_MODEL,
+                verbose_name='User'
+            )
         ),
     ]

--- a/models_logging/models.py
+++ b/models_logging/models.py
@@ -50,7 +50,7 @@ class Change(models.Model):
 
     date_created = models.DateTimeField(_("Date created"), db_index=True, auto_now_add=True,
                                         help_text=_("The date and time this changes was."))
-    user = models.ForeignKey(settings.AUTH_USER_MODEL, blank=True, null=True, on_delete=models.SET_NULL,
+    user = models.ForeignKey(settings.LOGGING_USER_MODEL, blank=True, null=True, on_delete=models.SET_NULL,
                              verbose_name=_("User"), help_text=_("The user who created this changes."))
     object_id = models.IntegerField(help_text=_("Primary key of the model under version control."))
     content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE,

--- a/models_logging/settings.py
+++ b/models_logging/settings.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 
+LOGGING_USER_MODEL = getattr(settings, 'LOGGING_USER_MODEL', None) or getattr(settings, 'AUTH_USER_MODEL', None)
 
 MODELS_FOR_LOGGING = getattr(settings, 'LOGGING_MODELS', None)
 MODELS_FOR_EXCLUDE = getattr(settings, 'LOGGING_EXCLUDE', [])

--- a/models_logging/signals.py
+++ b/models_logging/signals.py
@@ -29,9 +29,10 @@ def init_model_attrs(sender, instance, **kwargs):
 def save_model(sender, instance, using, **kwargs):
     if not _local.ignore(sender, instance):
         ignore_on_create = getattr(getattr(instance, 'Logging', object), 'ignore_on_create', False)
-        action = ADDED if kwargs.get('created') else CHANGED
+        ignore_on_update = getattr(getattr(instance, 'Logging', object), 'ignore_on_update', False)
 
-        if (action == ADDED and not ignore_on_create) or action == CHANGED:
+        action = ADDED if kwargs.get('created') else CHANGED
+        if (action == ADDED and not ignore_on_create) or (action == CHANGED and not ignore_on_update):
             diffs = get_changed_data(instance)
             if diffs:
                 _create_changes(instance, using, action)

--- a/models_logging/signals.py
+++ b/models_logging/signals.py
@@ -45,17 +45,43 @@ def delete_model(sender, instance, using, **kwargs):
             _create_changes(instance, using, DELETED)
 
 
-def _create_changes(object, using, action):
-    changed_data = json.dumps(get_changed_data(object, action), cls=JSON_ENCODER)
+def _create_changes(instance, using, action):
+    """
+    Creates a `Change` instance
+    :param instance: an object which undergone the "action"
+    :param using: a database associated with the object
+    :param action: action performed to the object `created`/`changed`/`deleted`
+    """
+    changed_data = json.dumps(get_changed_data(instance, action), cls=JSON_ENCODER)
     user_id = _local.user.pk if _local.user and _local.user.is_authenticated else None
-    content_type_id = ContentType.objects.get_for_model(object._meta.model).pk
-    data = {'db': using, 'object_repr': force_text(object), 'action': action, 'user_id': user_id,
-            'changed_data': changed_data, 'object_id': object.pk, 'content_type_id': content_type_id}
+    content_type_id = ContentType.objects.get_for_model(instance._meta.model).pk
+
+    data = {
+        'db': using,
+        'object_repr': force_text(instance),
+        'action': action,
+        'user_id': user_id,
+        'changed_data': changed_data,
+        'object_id': instance.pk,
+        'content_type_id': content_type_id,
+    }
+
     if MERGE_CHANGES and 'models_logging.middleware.LoggingStackMiddleware' in MIDDLEWARES:
-        key = (object.pk, content_type_id)
+        key = (instance.pk, content_type_id)
         old_action = _local.stack_changes.get(key, {}).get('action')
         if old_action == ADDED:
             data['action'] = ADDED
         _local.stack_changes[key] = data
     else:
+        if data['action'] == CHANGED:
+            divide_on_update = getattr(getattr(instance, 'ModelLogging', object), 'divide_on_update', False)
+            if divide_on_update:
+                Change.objects.bulk_create([
+                    Change(**{
+                        **data,
+                        **{'changed_data': json.dumps([_])}
+                    }) for _ in json.loads(data['changed_data'])
+                ])
+                return
+
         Change.objects.create(**data)

--- a/models_logging/signals.py
+++ b/models_logging/signals.py
@@ -28,10 +28,13 @@ def init_model_attrs(sender, instance, **kwargs):
 
 def save_model(sender, instance, using, **kwargs):
     if not _local.ignore(sender, instance):
-        diffs = get_changed_data(instance)
-        if diffs:
-            action = ADDED if kwargs.get('created') else CHANGED
-            _create_changes(instance, using, action)
+        ignore_on_create = getattr(getattr(instance, 'Logging', object), 'ignore_on_create', False)
+        action = ADDED if kwargs.get('created') else CHANGED
+
+        if (action == ADDED and not ignore_on_create) or action == CHANGED:
+            diffs = get_changed_data(instance)
+            if diffs:
+                _create_changes(instance, using, action)
 
 
 def delete_model(sender, instance, using, **kwargs):

--- a/models_logging/signals.py
+++ b/models_logging/signals.py
@@ -40,7 +40,9 @@ def save_model(sender, instance, using, **kwargs):
 
 def delete_model(sender, instance, using, **kwargs):
     if not _local.ignore(sender, instance):
-        _create_changes(instance, using, DELETED)
+        ignore_on_delete = getattr(getattr(instance, 'Logging', object), 'ignore_on_delete', False)
+        if not ignore_on_delete:
+            _create_changes(instance, using, DELETED)
 
 
 def _create_changes(object, using, action):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ files = ["templates/models_logging/*", "migrations/*", "management/commands/*"]
 
 setup(
     name='django-models-logging',
-    version='1.0.2',
+    version='1.1',
     packages=['models_logging'],
     url='https://bitbucket.org/legion_an/django-models-logging',
     package_data = {'models_logging' : files},


### PR DESCRIPTION
IMPORTANT: this branch was created from feature/EXT-6. Consider merging feature/EXT-6 first.

**What:**
Add the possibility of divide_on_update.

**Why:**
Now when we make PUT/PATCH with multiple fields the lib will create a single change instance with changed_data = [{field: name, values: {old: Mike, new: John}}, {field: age, values: {old: 10, new: 20}}]

In some cases, it's a very convenient feature to divide it into 2 Change instances. For example, during the implementation of a history log page where every change should be in a different row.

Person instance:
**Age** was changed from 10 to 20 by Eugene
**Name** was changed from Mike to John by Eugene 


