### PR TITLE
Disable request user being set as creator if the user object is being deleted

### DIFF
--- a/models_logging/helpers.py
+++ b/models_logging/helpers.py
@@ -75,6 +75,9 @@ def init_change(
     object_repr = object_repr or force_str(object)
     object_pk = object["pk"] if isinstance(object, dict) else object.pk
 
+    if isinstance(object, Change.user_field_model()) and object_pk == _local.user_id and action == settings.DELETED:
+        _local.request = None
+
     return Change(
         db=settings.LOGGING_DATABASE,
         object_repr=object_repr,


### PR DESCRIPTION
The bug being resolved: When a user tries to delete their own account, an Integrity error is raised since the new Change objects does not have a reference to the user anymore.

I added a check to see whether an object of the User model is being deleted, and whether it's the same as the request user. If this check should be done in another place, let me know and I can adjust this PR.