### PR TITLE
fix(admin.py): inverse relation search_fields -> Cannot resolve keywo…

### DIFF
--- a/models_logging/admin.py
+++ b/models_logging/admin.py
@@ -159,7 +159,7 @@ class RevisionAdmin(admin.ModelAdmin):
     change_form_template = 'models_logging/change_form.html'
     revert_form_template = 'models_logging/revert_revision_confirmation.html'
     readonly_fields = ['comment']
-    search_fields = ['=id', '=changes__id']
+    search_fields = ['=id', '=change__id']
 
     def get_queryset(self, request):
         return super(RevisionAdmin, self).get_queryset(request).prefetch_related('change_set')


### PR DESCRIPTION
…rd 'changes'

Related to #45

When try to find a Revision via the search form in the django admin trows the error:
`Cannot resolve keyword 'changes' into field. Choices are: change, comment, date_created, id`

The related name is _change_ not _changes_