### PR TITLE
fix: Add `MiddlewareNotUsed` handling when checking installed middlewares

### DIFF
--- a/models_logging/middleware.py
+++ b/models_logging/middleware.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.core.exceptions import MiddlewareNotUsed
 from django.utils.module_loading import import_string
 
 try:
@@ -31,7 +32,10 @@ class LoggingStackMiddleware(MiddlewareMixin):
 
 MERGE_CHANGES_ALLOWED = False
 for middleware in settings.MIDDLEWARE:
-    middleware_cls = import_string(middleware)(object)
+    try:
+        middleware_cls = import_string(middleware)(object)
+    except MiddlewareNotUsed:
+        continue
 
     if isinstance(middleware_cls, LoggingStackMiddleware):
         MERGE_CHANGES_ALLOWED = True


### PR DESCRIPTION
Hi!  I found a bug where the middleware pre-check was importing every middleware looking for a `LoggingStackMiddleware` instance. Some middleware implementations can raise `MiddlewareNotUsed` to signal that Django should ignore them ([see Django docs](https://docs.djangoproject.com/es/4.2//topics/http/middleware/#marking-middleware-as-unused)).

This change catches `MiddlewareNotUsed` during middleware instantiation and skips those entries, preventing crashes during the pre-check process.